### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a package that offers a way to load mock responses conditionally based o
 Install this package using composer:
 
 ```
-composer require-dev webwhales/guzzle-conditional-mock-handler
+composer require --dev webwhales/guzzle-conditional-mock-handler
 ```
 
 


### PR DESCRIPTION
Composer does not have a `require-dev` command, but it does have a `--dev` option for the `require` command, so use that instead.